### PR TITLE
Dev/removesignature

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -14,3 +14,4 @@ __tests__
 /example/
 /src/
 android/.gradle/
+tsconfig.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 1.1.0
+* Enhancement: Update the Xcode project to add a new script when installing the app on a device.
 ## 1.0.5
 * Enhancement: Fine-tune android permissions
 ## 1.0.2

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@woosmap/expo-plugin-geofencing-batch",
-	"version": "1.0.5",
+	"version": "1.1.0",
   "description": "Woosmap geofencing and batch integration",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/configWoosmapGeofencingIOS.ts
+++ b/src/configWoosmapGeofencingIOS.ts
@@ -97,24 +97,41 @@ const withSDKDangerousMod: ConfigPlugin<ConfigProps> = (config, props) => {
 };
 
 
-const withSDKXcodeProject =  (config, props) => {
-  const shellScript = `
-  echo "Remove WoosmapGeofencing signature file"
-  rm -rf "$BUILD_DIR/\${CONFIGURATION}-iphoneos/WoosmapGeofencing.xcframework-ios.signature"
-  `;
+const withSDKXcodeProject: ConfigPlugin<ConfigProps> =  (config,props) => {
+  
   return withXcodeProject(config, async (config) => {
-    const xcodeProject = config.modResults;
 
-    xcodeProject.addBuildPhase(
+    const xcodeProject = config.modResults;
+    const PHASE_NAME = 'Remove WoosmapGeofencing signature file';
+    const shellScript = `echo "Remove WoosmapGeofencing signature file"
+  rm -rf "$BUILD_DIR/\${CONFIGURATION}-iphoneos/WoosmapGeofencing.xcframework-ios.signature"`;
+
+    // -----------------------------
+    // 1) Prevent duplicate insertion
+    // -----------------------------
+    const existingPhases = xcodeProject.pbxItemByComment(PHASE_NAME, 'PBXShellScriptBuildPhase');
+    if (existingPhases) {
+      console.log(`⚠️ '${PHASE_NAME}' phase already exists, skipping creation.`);
+      return config;
+    }
+
+
+    const phaseUUID =  xcodeProject.addBuildPhase(
       [],
       'PBXShellScriptBuildPhase',
-      'Remove WoosmapGeofencing signature file',
+      PHASE_NAME,
       null,
       {
         shellPath: '/bin/sh',
         shellScript,
       },
     );
+
+    // Patch the field manually
+    const phase = xcodeProject.pbxItemByComment(PHASE_NAME, 'PBXShellScriptBuildPhase');//pbxShellScriptBuildPhaseObj(phaseUUID);
+    phase.runOnlyForDeploymentPostprocessing = 1;
+    console.log(`✅ Added '${PHASE_NAME}' phase to Xcode project.`);
+
     return config;
   });
 };
@@ -122,7 +139,7 @@ const withSDKXcodeProject =  (config, props) => {
 export const withIOSSdk: ConfigPlugin<ConfigProps> = (config, props) => {
   config = withSDKInfoPlist(config, props);
   //   config = withSDKEntitlements(config, props);
-  config = withSDKXcodeProject(config, props);
+  config = withSDKXcodeProject(config,props);
   config = withSDKDangerousMod(config, props);
   return config;
 };

--- a/src/configWoosmapGeofencingIOS.ts
+++ b/src/configWoosmapGeofencingIOS.ts
@@ -2,6 +2,7 @@ import {
   ConfigPlugin,
   withInfoPlist,
   withDangerousMod,
+  withXcodeProject,
 } from "@expo/config-plugins";
 
 import { ConfigProps } from "./types";
@@ -94,10 +95,35 @@ const withSDKDangerousMod: ConfigPlugin<ConfigProps> = (config, props) => {
     },
   ]);
 };
+
+
+const withSDKXcodeProject =  (config, props) => {
+
+  const shellScript = `
+    echo "Remove WoosmapGeofencing signature file"
+    rm -rf "$BUILD_DIR/Release-iphoneos/WoosmapGeofencing.xcframework-ios.signature"
+`;
+  return withXcodeProject(config, async (config) => {
+    const xcodeProject = config.modResults;
+
+    xcodeProject.addBuildPhase(
+      [],
+      'PBXShellScriptBuildPhase',
+      'Remove WoosmapGeofencing signature file',
+      null,
+      {
+        shellPath: '/bin/sh',
+        shellScript,
+      },
+    );
+    return config;
+  });
+};
+
 export const withIOSSdk: ConfigPlugin<ConfigProps> = (config, props) => {
   config = withSDKInfoPlist(config, props);
   //   config = withSDKEntitlements(config, props);
-  //   config = withSDKXcodeProject(config, props);
+  config = withSDKXcodeProject(config, props);
   config = withSDKDangerousMod(config, props);
   return config;
 };

--- a/src/configWoosmapGeofencingIOS.ts
+++ b/src/configWoosmapGeofencingIOS.ts
@@ -98,11 +98,10 @@ const withSDKDangerousMod: ConfigPlugin<ConfigProps> = (config, props) => {
 
 
 const withSDKXcodeProject =  (config, props) => {
-
   const shellScript = `
-    echo "Remove WoosmapGeofencing signature file"
-    rm -rf "$BUILD_DIR/Release-iphoneos/WoosmapGeofencing.xcframework-ios.signature"
-`;
+  echo "Remove WoosmapGeofencing signature file"
+  rm -rf "$BUILD_DIR/\${CONFIGURATION}-iphoneos/WoosmapGeofencing.xcframework-ios.signature"
+  `;
   return withXcodeProject(config, async (config) => {
     const xcodeProject = config.modResults;
 

--- a/src/configWoosmapGeofencingIOS.ts
+++ b/src/configWoosmapGeofencingIOS.ts
@@ -130,8 +130,7 @@ const withSDKXcodeProject: ConfigPlugin<ConfigProps> =  (config,props) => {
     // Patch the field manually
     const phase = xcodeProject.pbxItemByComment(PHASE_NAME, 'PBXShellScriptBuildPhase');//pbxShellScriptBuildPhaseObj(phaseUUID);
     phase.runOnlyForDeploymentPostprocessing = 1;
-    console.log(`✅ Added '${PHASE_NAME}' phase to Xcode project.`);
-
+    
     return config;
   });
 };

--- a/whatsnew.md
+++ b/whatsnew.md
@@ -1,1 +1,1 @@
-* Enhancement: Update Xcode project to add add new script while installing app with device
+* Enhancement: Update the Xcode project to add a new script when installing the app on a device.

--- a/whatsnew.md
+++ b/whatsnew.md
@@ -1,1 +1,1 @@
-* Enhancement: Fine-tune android permissions
+* Enhancement: Update Xcode project to add add new script while installing app with device


### PR DESCRIPTION
<!-- The title of the PR ↑↑↑ above should provide a general summary of what it is about. -->
<!-- Warning: any PR that has missing info is not ready to be reviewed. -->

## Issue
<!-- Link the PR to one or more tasks/epics/bugs. -->
<!-- Use # followed by the issue ID. 
#1234 or closes #1234 or closes Woosmap/woosmap#1234
-->

## Describe your changes
This pull request proposes adding a script to remove a signature file during the iOS app build process and updates project documentation accordingly.
- Adds a new build script:
-  Integrates a shell script into the Xcode build process to delete ‘WoosmapGeofencing.xcframework-ios.signature’ after building for iPhone OS.
- Checks if the phase already exists to prevent duplicates.
- Logs actions to the console.

## How to test
Please run the following script to test it
```
npm install
npx expo-module build
```
And then run expo example app
```
cd example
npm install
npx expo prebuild --ios
```

It will create a new iOS folder. Open expoplugingeofencingbatchexample.xcworkspace and check build phases.

![Screenshot 2025-12-08 at 11 10 28 AM](https://github.com/user-attachments/assets/809df54a-6493-4cb8-ba42-7a837f532a55)


## Checklist:
<!-- Please go through this list. Don't just tick the boxes, verify each one. -->

- [ ] My code follows the style guidelines for this repo
- [ ] My code passes the SonarCloud check and does not add new code smells
- [ ] I have performed a self-review of my code
- [ ] My changes generate no new warnings/errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I don't require ops changes for this PR to go to prod
- [ ] This change does not include a migration

### Documentation
<!-- Create issues to track any required documentation changes and include them here -->

### Libs/SDKs
<!-- Create issues to track any required library or SDK changes and include them here -->
