### PR TITLE
Use OIDC to publish plugin

### DIFF
--- a/.github/workflows/OnNPM.yaml
+++ b/.github/workflows/OnNPM.yaml
@@ -34,7 +34,7 @@ jobs:
           
       - name: Publish
         run: |
-          npm publish --access public
+          npm publish --access public --tag beta 
         
           
       - name: Create a GitHub release

--- a/.github/workflows/OnNPM.yaml
+++ b/.github/workflows/OnNPM.yaml
@@ -14,11 +14,13 @@ jobs:
     steps:
       - name: Check out Git repository
         uses: actions/checkout@v4
+      
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           registry-url: 'https://registry.npmjs.org/'
+      
       - name: Capture plugin version
         run: |
           _pluginVersion=$(node -p "require('./package.json').version")
@@ -33,8 +35,7 @@ jobs:
       - name: Publish
         run: |
           npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+        
           
       - name: Create a GitHub release
         uses: ncipollo/release-action@v1

--- a/.github/workflows/OnNPM.yaml
+++ b/.github/workflows/OnNPM.yaml
@@ -35,7 +35,7 @@ jobs:
           
       - name: Publish
         run: |
-          npm publish --access public --tag beta 
+          npm publish --access public
        
       - name: Create a GitHub release
         uses: ncipollo/release-action@v1

--- a/.github/workflows/OnNPM.yaml
+++ b/.github/workflows/OnNPM.yaml
@@ -11,6 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      id-token: write  # Required for OIDC
     steps:
       - name: Check out Git repository
         uses: actions/checkout@v4

--- a/.github/workflows/predict_version.yml
+++ b/.github/workflows/predict_version.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Setup Node.js
       uses: actions/setup-node@v4
       with:
-        node-version: 20.x
+        node-version: 24
         registry-url: https://registry.npmjs.org/
 
     - name: Checkout base branch
@@ -139,7 +139,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-         node-version: 18.x
+         node-version: 24
          registry-url: https://registry.npmjs.org/
          
       - name: set up JDK 17

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 1.1.1
+* Enhancement: Update publishing process workflow
 ## 1.1.0
 * Enhancement: Update the Xcode project to add a new script when installing the app on a device.
 ## 1.0.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.1.1
+## 1.1.0
 * Enhancement: Update publishing process workflow
 ## 1.1.0
 * Enhancement: Update the Xcode project to add a new script when installing the app on a device.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.1.0
+## 1.1.1
 * Enhancement: Update publishing process workflow
 ## 1.1.0
 * Enhancement: Update the Xcode project to add a new script when installing the app on a device.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@woosmap/expo-plugin-geofencing-batch",
-	"version": "1.1.0",
+	"version": "1.1.1-beta.3",
   "description": "Woosmap geofencing and batch integration",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -15,14 +15,14 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Woosmap/geofencing-react-native-plugin.git"
+    "url": "https://github.com/Woosmap/expo_plugin_geofencing_batch.git"
   },
   "bugs": {
-    "url": "https://github.com/Woosmap/geofencing-react-native-plugin/issues"
+    "url": "https://github.com/Woosmap/expo_plugin_geofencing_batch/issues"
   },
   "author": "Woosmap <operations@woosmap.com> (https://www.woosmap.com/en/contact)",
   "license": "MIT",
-  "homepage": "https://github.com/Woosmap/geofencing-react-native-plugin#readme",
+  "homepage": "https://github.com/Woosmap/expo_plugin_geofencing_batch#readme",
   "scripts": {
     "build": "expo-module build",
     "clean": "expo-module clean"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@woosmap/expo-plugin-geofencing-batch",
-	"version": "1.1.0",
+	"version": "1.1.1",
   "description": "Woosmap geofencing and batch integration",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@woosmap/expo-plugin-geofencing-batch",
-	"version": "1.1.1",
+	"version": "1.1.0",
   "description": "Woosmap geofencing and batch integration",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/Woosmap/expo_plugin_geofencing_batch.git"
+    "url": "git+https://github.com/Woosmap/expo_plugin_geofencing_batch.git"
   },
   "bugs": {
     "url": "https://github.com/Woosmap/expo_plugin_geofencing_batch/issues"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@woosmap/expo-plugin-geofencing-batch",
-	"version": "1.1.1-beta.3",
+	"version": "1.1.0",
   "description": "Woosmap geofencing and batch integration",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/whatsnew.md
+++ b/whatsnew.md
@@ -1,1 +1,1 @@
-* Enhancement: Update the Xcode project to add a new script when installing the app on a device.
+* Enhancement: Update publishing process workflow


### PR DESCRIPTION
<!-- The title of the PR ↑↑↑ above should provide a general summary of what it is about. -->
<!-- Warning: any PR that has missing info is not ready to be reviewed. -->

## Issue
#18

## Describe your changes
It introduces minor configuration and metadata updates related to publishing the Expo geofencing plugin
- Updates Node.js version used for publishing from 20 to 24.
- Removed use of `NODE_AUTH_TOKEN` and use OIDC publishing
- Added new permission ID token to workflow
- Updates repository.url, bugs.url, and homepage to point to expo_plugin_geofencing_batch instead of geofencing-react-native-plugin.

## How to test
<!-- Describe how to test your change. This is probably the most important part of a PR, DO NOT LEAVE IT EMPTY --> 
Merging this branch will publish a new plugin version on NPM

## Checklist:
<!-- Please go through this list. Don't just tick the boxes, verify each one. -->

- [x] My code follows the style guidelines for this repo
- [x] My code passes the SonarCloud check and does not add new code smells
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings/errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I don't require ops changes for this PR to go to prod
- [x] This change does not include a migration

### Documentation
<!-- Create issues to track any required documentation changes and include them here -->

### Libs/SDKs
<!-- Create issues to track any required library or SDK changes and include them here -->
